### PR TITLE
Updated Windows CMD to mount to Linux MobyVM

### DIFF
--- a/Docker-ACS/Challenges/Docker-Storage/mongodb.cmd
+++ b/Docker-ACS/Challenges/Docker-Storage/mongodb.cmd
@@ -4,4 +4,4 @@ docker ps -a
 docker rm mongodb
 
 @REM windows
-docker run --name mongodb -v /c/MongoDBData:/data/db -d mongo
+docker run -d --name mongodb --mount source=MongoDBData,target=/data/db mongo


### PR DESCRIPTION
As per Docker recommendations for using external storage volume on the Linux VM, not the Windows host.