### PR TITLE
Updating docker build and debug to support windows/vscode

### DIFF
--- a/Docker-ACS/Labs/Exercise3/backend/server.go
+++ b/Docker-ACS/Labs/Exercise3/backend/server.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-func shouldbemain() {
+func main() {
 
 	fmt.Println("Hooking up hanlders...")
 

--- a/Docker-ACS/Labs/Exercise3/backend/server.go
+++ b/Docker-ACS/Labs/Exercise3/backend/server.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-func main() {
+func shouldbemain() {
 
 	fmt.Println("Hooking up hanlders...")
 

--- a/Docker-ACS/Labs/Exercise3/frontend/.dockerignore
+++ b/Docker-ACS/Labs/Exercise3/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Docker-ACS/Labs/Exercise3/frontend/.vscode/tasks.json
+++ b/Docker-ACS/Labs/Exercise3/frontend/.vscode/tasks.json
@@ -4,19 +4,23 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "Build Container",
-            "type": "shell",
-            "command": "docker build . -t debugimage"
-        },
-        {
-            "taskName": "Stop Container",
+            // In case there's a docker container running, make sure to remove it
+            "label": "Stop Container",
             "type": "shell",
             "command": "docker rm -f debuginstance"
         },
         {
-            "taskName": "Run Container",
-            "type": "shell",            
-            "command": "docker run --rm -v ${workspaceRoot}:/code -p 8182:8000 -p 9339:9339 --name debuginstance debugimage nodemon -L --inspect-brk=0.0.0.0:9339",
+            "label": "Build Container",
+            "type": "shell",
+            "command": "docker build . -t debugimage",
+            "dependsOn": [
+                "Stop Container"
+            ]
+        },
+        {
+            "label": "Run Container",
+            "type": "shell",
+            "command": "docker run --rm -p 8182:8000 -p 9339:9339 --name debuginstance debugimage nodemon -L --inspect-brk=0.0.0.0:9339",
             "isBackground": true,
             "promptOnClose": true,
             "dependsOn": [
@@ -24,8 +28,9 @@
             ]
         },
         {
-            "taskName": "Build and Run Container",
+            "label": "Build and Run Container",
             "type": "shell",
+            "command": "echo \"build & run completed\"",
             "dependsOn": [
                 "Run Container"
             ],

--- a/Docker-ACS/Labs/Exercise3/frontend/.vscode/tasks.json
+++ b/Docker-ACS/Labs/Exercise3/frontend/.vscode/tasks.json
@@ -20,7 +20,7 @@
         {
             "label": "Run Container",
             "type": "shell",
-            "command": "docker run --rm -p 8182:8000 -p 9339:9339 --name debuginstance debugimage nodemon -L --inspect-brk=0.0.0.0:9339",
+            "command": "docker run --rm -v \"${workspaceRoot}:/code\" -p 8182:8000 -p 9339:9339 --name debuginstance debugimage nodemon -L --inspect-brk=0.0.0.0:9339",
             "isBackground": true,
             "promptOnClose": true,
             "dependsOn": [
@@ -34,6 +34,9 @@
             "dependsOn": [
                 "Run Container"
             ],
+            "options": {
+                
+            },
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/Docker-ACS/Labs/Exercise3/frontend/.vscode/tasks.json
+++ b/Docker-ACS/Labs/Exercise3/frontend/.vscode/tasks.json
@@ -28,6 +28,16 @@
             ]
         },
         {
+            "label": "Run Container Linux",
+            "type": "shell",
+            "command": "docker run --rm -v ${workspaceRoot}:/code -p 8182:8000 -p 9339:9339 --name debuginstance debugimage nodemon -L --inspect-brk=0.0.0.0:9339",
+            "isBackground": true,
+            "promptOnClose": true,
+            "dependsOn": [
+                "Build Container"
+            ]
+        },
+        {
             "label": "Build and Run Container",
             "type": "shell",
             "command": "echo \"build & run completed\"",

--- a/Docker-ACS/Labs/Exercise3/frontend/Dockerfile
+++ b/Docker-ACS/Labs/Exercise3/frontend/Dockerfile
@@ -1,13 +1,11 @@
 FROM node:latest
 
+RUN mkdir /src
 WORKDIR /code
 
 RUN npm install -g nodemon@1.11.0
 
-COPY package.json /code/package.json
-RUN npm install && npm ls
-RUN mv /code/node_modules /node_modules
-
 COPY . /code
+RUN npm install
 
-CMD ["npm", "start"]
+CMD "npm" "start"

--- a/Docker-ACS/Labs/Exercise3/frontend/Dockerfile
+++ b/Docker-ACS/Labs/Exercise3/frontend/Dockerfile
@@ -1,11 +1,17 @@
 FROM node:latest
 
-RUN mkdir /src
+RUN mkdir code
 WORKDIR /code
 
 RUN npm install -g nodemon@1.11.0
 
+# This command will not copy node_modules because .dockerignore excempts it
 COPY . /code
-RUN npm install
+RUN npm install 
+
+# This would work because npm will search node_modules in the upper directory
+# Unless it is installed in the local environment, in which case it would be mirrored
+# when running the "docker run" command
+RUN mv /code/node_modules /node_modules
 
 CMD ["npm", "start"]

--- a/Docker-ACS/Labs/Exercise3/frontend/Dockerfile
+++ b/Docker-ACS/Labs/Exercise3/frontend/Dockerfile
@@ -8,4 +8,4 @@ RUN npm install -g nodemon@1.11.0
 COPY . /code
 RUN npm install
 
-CMD "npm" "start"
+CMD ["npm", "start"]

--- a/Docker-ACS/Labs/Exercise3/frontend/package.json
+++ b/Docker-ACS/Labs/Exercise3/frontend/package.json
@@ -1,5 +1,11 @@
 {
     "main": "app.js",
+    "repository": {
+        "type" : "git",
+        "url": "https://github.com/torosent/containers-k8s-workshop"
+    },
+    "license": "MIT",
+    "description": "This is the front end application we run in the container",
     "dependencies": {
         "express": "~4.14.0",
         "express-handlebars": "~3.0.0"

--- a/Docker-ACS/Labs/docker101.md
+++ b/Docker-ACS/Labs/docker101.md
@@ -287,7 +287,7 @@ cd [location of labs git here]/Docker-ACS/Labs/Exercise3/backend/
 ```
 Let’s look at our backend code using vscode, run the following
 
-```
+```bash
 code .
 ```
 
@@ -346,7 +346,7 @@ Hooking up hanlders...
 Running server...
 ```
 
-How we’ve fixed the bug let’s use the dockerfile*  to build a docker image and use this to run the backend. Use ‘ctrl-c’ and then ‘exit’ to leave golang tools container. Now build the docker file:
+Now that we’ve fixed the bug, let’s use the dockerfile*  to build a docker image and use this to run the backend. Press ‘ctrl-c’ to stop the go server from running then type ‘exit’ to leave golang tools container. Now build the docker file:
 
 > *This file uses the golang container to build our application then copies the binary into a new container, which doesn’t contain all the golang build tools. This keeps the container image nice and small for speedy deployments. 
 
@@ -359,9 +359,9 @@ Open a browser and test the service by hitting [http://localhost:8181/bar](http:
 
 ### Build and Debug the Frontend (Adapted from [Docker-tools lab](https://github.com/docker/labs/blob/master/developer-tools/nodejs-debugging/VSCode-README.md))
 
-Now let’s get the frontend setup, surprise surprise we’ll run this in a container. In the frontend, let’s pretend there a more complex bug which we’ll need to debug through VSCode. 
+Next, let’s setup the frontend, and, surprise surprise, we’ll run this in a container. In the frontend, let’s pretend there's a more complex bug which we’ll need to debug through VSCode. 
 
-Open the directory and start VSCode
+Open the directory and start VSCode:
 
 ```bash
 cd [location of labs git repo]/Docker-ACS/Labs/Exercise3/frontend/


### PR DESCRIPTION
Changes:
* Removing some excess parameters (`-v ${workspaceRoot}:/code` is not needed since we copy this directory in `Dockerfile` - this seems to fix the problem with vscode debugging)
* change tasks.json to newer version (taskName ==> label)
* Fix package.json so no warning messages appear on build output
* Fix grammar